### PR TITLE
docs: add OSSF and crate badges to mdbook

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,5 +1,10 @@
 # Introduction
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11947/badge)](https://www.bestpractices.dev/projects/11947)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/EvilBit-Labs/libmagic-rs/badge)](https://scorecard.dev/viewer/?uri=github.com/EvilBit-Labs/libmagic-rs)
+[![Crates.io](https://img.shields.io/crates/v/libmagic-rs)](https://crates.io/crates/libmagic-rs)
+[![License](https://img.shields.io/crates/l/libmagic-rs)](https://github.com/EvilBit-Labs/libmagic-rs/blob/main/LICENSE)
+
 Welcome to the **libmagic-rs** developer guide! This documentation provides comprehensive information about the pure-Rust implementation of libmagic, the library that powers the `file` command for identifying file types.
 
 ## What is libmagic-rs?


### PR DESCRIPTION
## Summary

- Add OSSF Best Practices, OpenSSF Scorecard, crates.io, and license badges to the mdbook introduction page
- OSSF Best Practices requires the badge on the project website (evilbitlabs.io/libmagic-rs/)

## Test plan

- [ ] Verify badges render correctly in mdbook (`mdbook serve`)
- [ ] Confirm badge links resolve to correct targets