### PR TITLE
fix(review): address PR #288 review feedback follow-ups

### DIFF
--- a/docs/MAGIC_FORMAT.md
+++ b/docs/MAGIC_FORMAT.md
@@ -214,7 +214,7 @@ Examples:
 0       pstring/HJ =JPEG        JPEG image (2-byte BE, self-inclusive length)
 ```
 
-If `max_length` is specified in the magic file (not shown in the basic syntax), it caps the length value to prevent reading excessive data. This guards against attacker-controlled length-prefix saturation attacks where malicious files specify extreme length values.
+The `pstring` magic-file surface syntax does not accept a `max_length` value -- only the `/B`, `/H`, `/h`, `/L`, `/l`, and `/J` width/flag suffixes. The AST field `max_length: Option<usize>` is reserved for programmatic rule construction (e.g., callers building `TypeKind::PString { max_length: Some(N), ... }` directly) and for future grammar extensions. When set, it caps the length value to guard against attacker-controlled length-prefix saturation attacks where malicious files specify extreme length values; rules loaded from `.magic` text always have `max_length: None`.
 
 **UCS-2 Strings (lestring16 / bestring16)**
 
@@ -231,16 +231,16 @@ Examples:
 
 Flags for `string` type modify comparison behavior per libmagic `src/softmagic.c`:
 
-| Flag | Description                                                                                                          |
-| ---- | -------------------------------------------------------------------------------------------------------------------- |
-| `/c` | Case-insensitive match (lowercase pattern chars fold file bytes to lower; uppercase pattern chars are literal)      |
-| `/C` | Case-insensitive match (uppercase pattern chars fold file bytes to upper; lowercase pattern chars are literal)      |
-| `/w` | Whitespace-optional (pattern whitespace matches zero or more file whitespace)                                       |
+| Flag | Description                                                                                                            |
+| ---- | ---------------------------------------------------------------------------------------------------------------------- |
+| `/c` | Case-insensitive match (lowercase pattern chars fold file bytes to lower; uppercase pattern chars are literal)         |
+| `/C` | Case-insensitive match (uppercase pattern chars fold file bytes to upper; lowercase pattern chars are literal)         |
+| `/w` | Whitespace-optional (pattern whitespace matches zero or more file whitespace)                                          |
 | `/W` | Whitespace-required-compact (pattern whitespace requires at least one file whitespace; additional whitespace consumed) |
-| `/T` | Trim leading/trailing ASCII whitespace from pattern before comparison                                               |
-| `/f` | Full-word match (post-match word-boundary check; next byte must be EOF or non-word char)                            |
-| `/b` | Force binary test (MIME-output hint; no effect on comparison)                                                       |
-| `/t` | Force text test (MIME-output hint; no effect on comparison)                                                         |
+| `/T` | Trim leading/trailing ASCII whitespace from pattern before comparison                                                  |
+| `/f` | Full-word match (post-match word-boundary check; next byte must be EOF or non-word char)                               |
+| `/b` | Force binary test (MIME-output hint; no effect on comparison)                                                          |
+| `/t` | Force text test (MIME-output hint; no effect on comparison)                                                            |
 
 **`/c` vs `/C` asymmetry:** The pattern character controls fold direction. `/c` with lowercase pattern chars folds the file byte to lowercase; uppercase pattern chars in the same pattern are compared literally. Mixed-case patterns work intuitively: `/c FoO` matches `FoO`, `Foo`, `FOO` but not `fOO` (the uppercase `F` is literal). See GOTCHAS S6.5 for details.
 
@@ -322,13 +322,13 @@ Match byte patterns using regular expressions. The `regex` type uses `regex::byt
 offset  regex[/count[unit]][flags]  pattern  message
 ```
 
-| Component   | Required | Description                                           |
-| ----------- | -------- | ----------------------------------------------------- |
-| `/count`    | No       | Numeric cap: bytes scanned (default)                  |
-| `unit`      | No       | `l` suffix = line count cap instead of byte count     |
-| `/c`        | No       | Case-insensitive matching                             |
-| `/s`        | No       | Anchor advance to match-start (default: match-end)    |
-| `/l`        | No       | Line-bounded scan window (stops at newline)           |
+| Component | Required | Description                                        |
+| --------- | -------- | -------------------------------------------------- |
+| `/count`  | No       | Numeric cap: bytes scanned (default)               |
+| `unit`    | No       | `l` suffix = line count cap instead of byte count  |
+| `/c`      | No       | Case-insensitive matching                          |
+| `/s`      | No       | Anchor advance to match-start (default: match-end) |
+| `/l`      | No       | Line-bounded scan window (stops at newline)        |
 
 **Flags:**
 

--- a/docs/src/ast-structures.md
+++ b/docs/src/ast-structures.md
@@ -504,7 +504,7 @@ let combined = TypeKind::String {
 };
 ```
 
-`StringFlags::default()` constructs a value with every flag set to `false`. The `is_empty(&self) -> bool` method returns `true` for such a value, and the engine uses it as the fast-path predicate: rules with default flags take the byte-exact comparison path, while any non-default flag routes the rule through `compare_string_with_flags`.
+`StringFlags::default()` constructs a value with every flag set to `false`. The `is_empty(self) -> bool` method (takes `self` by value; `StringFlags` is `Copy`) returns `true` for such a value, and the engine uses it as the fast-path predicate: rules with default flags take the byte-exact comparison path, while any non-default flag routes the rule through `compare_string_with_flags`.
 
 **Note:** `/B` is NOT a string flag — it is the `pstring` 1-byte length-width letter. `string/B` is rejected at parse time.
 

--- a/docs/src/magic-format.md
+++ b/docs/src/magic-format.md
@@ -285,7 +285,7 @@ The optional max_length parameter caps the length value:
 
 ### String Flags
 
-String flags are now implemented as of PR #234, providing libmagic-compatible string comparison semantics.
+String flags are now implemented (issue #234, landed in PR #288), providing libmagic-compatible string comparison semantics.
 
 | Flag | Description                                                   |
 | ---- | ------------------------------------------------------------- |

--- a/src/evaluator/strength.rs
+++ b/src/evaluator/strength.rs
@@ -72,14 +72,17 @@ pub fn calculate_default_strength(rule: &MagicRule) -> i32 {
     // Type contribution: more specific types get higher strength
     strength += match &rule.typ {
         // Strings are most specific (they match exact byte sequences).
-        // Flagged strings get a per-flag penalty because the flags broaden
+        // Flagged strings get a per-flag penalty because some flags broaden
         // what the rule matches: `string/c FOO` matches both `FOO` and
         // `foo`, so it should sort BELOW `string FOO` (which only matches
         // `FOO` exactly) under stop_at_first_match. This mirrors libmagic's
         // `apprentice.c::apprentice_magic_strength` which subtracts 1 per
         // `STRING_IGNORE_*` flag bit. We extend the penalty to whitespace
-        // and full-word flags by the same logic: each flag that makes the
-        // pattern fuzzier costs one point.
+        // flags (`/w` and `/W`) by the same logic. `/f` (full-word) is
+        // NOT penalized because it tightens the match (requires a word
+        // boundary) rather than broadening it; `/T` (trim) and the
+        // MIME-output hints (`/t`, `/b`) carry no penalty either -- see
+        // `string_flag_specificity_penalty` for the canonical list.
         TypeKind::String { max_length, flags } => {
             let base = 20;
             let with_length_bonus = if max_length.is_some() { base + 5 } else { base };
@@ -213,17 +216,22 @@ pub fn calculate_default_strength(rule: &MagicRule) -> i32 {
 /// Count how many `string`-flag bits make a rule's pattern fuzzier.
 ///
 /// libmagic `apprentice.c::apprentice_magic_strength` subtracts 1 from the
-/// computed strength for each `STRING_IGNORE_*` bit set. We extend the same
-/// reasoning to whitespace and full-word flags: each flag that broadens
-/// what the rule matches reduces its specificity by one point.
+/// computed strength for each `STRING_IGNORE_*` bit set. We extend the
+/// same reasoning to the whitespace flags (`/w` and `/W`) because they
+/// broaden what the rule matches.
 ///
-/// Flags that do NOT affect comparison (`/t` text-test, `/b` bin-test --
-/// MIME hints only) carry no penalty. `/T` (`STRING_TRIM`) is a
-/// pattern-side normalization, not a fuzziness flag, so it does not
-/// penalize either. `/f` (`STRING_FULL_WORD`) tightens the match by
-/// requiring a post-match word boundary, but it does so independently
-/// of any per-byte fuzziness -- it goes the other direction
-/// semantically, so we leave it untouched as well.
+/// Penalized flags (each costs 1 point):
+/// - `/c` (`ignore_lowercase`) -- ASCII case-fold when pattern is lowercase
+/// - `/C` (`ignore_uppercase`) -- ASCII case-fold when pattern is uppercase
+/// - `/w` (`compact_optional_whitespace`) -- file whitespace optional
+/// - `/W` (`compact_whitespace`) -- file whitespace required but elastic
+///
+/// Non-penalized flags (no specificity change):
+/// - `/t` (`text_test`) and `/b` (`bin_test`) -- MIME-output hints only
+/// - `/T` (`trim`) -- pattern-side normalization, not a fuzziness knob
+/// - `/f` (`full_word`) -- TIGHTENS the match by requiring a post-match
+///   word boundary; opposite direction from fuzziness, so it should not
+///   be penalized.
 fn string_flag_specificity_penalty(flags: crate::parser::ast::StringFlags) -> i32 {
     let mut penalty = 0;
     if flags.ignore_lowercase {
@@ -1228,5 +1236,106 @@ mod tests {
             calculate_default_strength(&default_rule),
             "Name strength should equal Default strength (both type-axis 0)"
         );
+    }
+
+    /// Pin the canonical penalty per flag bit (pinned by request from
+    /// the `CodeRabbit` PR #288 review). Each row asserts which flags
+    /// reduce rule specificity (penalized) versus which do not
+    /// (non-penalized).
+    ///
+    /// **Penalized**: `/c`, `/C`, `/w`, `/W` -- they broaden the match.
+    /// **Non-penalized**: `/T` (pattern-side trim, not fuzziness), `/b`
+    /// and `/t` (MIME-output hints, no comparison effect), `/f`
+    /// (TIGHTENS the match by requiring a word boundary).
+    ///
+    /// Penalties also stack additively across multiple penalized flags
+    /// (e.g., `/cw` = 2 points).
+    #[test]
+    fn string_flag_specificity_penalty_per_flag_table() {
+        let cases: &[(&str, StringFlags, i32)] = &[
+            ("no flags", StringFlags::default(), 0),
+            (
+                "/c only",
+                StringFlags::default().with_ignore_lowercase(true),
+                1,
+            ),
+            (
+                "/C only",
+                StringFlags::default().with_ignore_uppercase(true),
+                1,
+            ),
+            (
+                "/w only",
+                StringFlags::default().with_compact_optional_whitespace(true),
+                1,
+            ),
+            (
+                "/W only",
+                StringFlags::default().with_compact_whitespace(true),
+                1,
+            ),
+            (
+                "/T only (non-penalized)",
+                StringFlags::default().with_trim(true),
+                0,
+            ),
+            (
+                "/t only (non-penalized)",
+                StringFlags::default().with_text_test(true),
+                0,
+            ),
+            (
+                "/b only (non-penalized)",
+                StringFlags::default().with_bin_test(true),
+                0,
+            ),
+            (
+                "/f only (non-penalized)",
+                StringFlags::default().with_full_word(true),
+                0,
+            ),
+            (
+                "/cw stacks (case + whitespace)",
+                StringFlags::default()
+                    .with_ignore_lowercase(true)
+                    .with_compact_optional_whitespace(true),
+                2,
+            ),
+            (
+                "/cC stacks (both case folds)",
+                StringFlags::default()
+                    .with_ignore_lowercase(true)
+                    .with_ignore_uppercase(true),
+                2,
+            ),
+            (
+                "all four penalized flags",
+                StringFlags::default()
+                    .with_ignore_lowercase(true)
+                    .with_ignore_uppercase(true)
+                    .with_compact_whitespace(true)
+                    .with_compact_optional_whitespace(true),
+                4,
+            ),
+            (
+                "mixed: 2 penalized + 4 non-penalized",
+                StringFlags::default()
+                    .with_ignore_lowercase(true)
+                    .with_compact_whitespace(true)
+                    .with_trim(true)
+                    .with_text_test(true)
+                    .with_bin_test(true)
+                    .with_full_word(true),
+                2,
+            ),
+        ];
+
+        for (label, flags, expected) in cases {
+            let actual = string_flag_specificity_penalty(*flags);
+            assert_eq!(
+                actual, *expected,
+                "case {label}: expected penalty {expected}, got {actual}"
+            );
+        }
     }
 }

--- a/src/evaluator/types/mod.rs
+++ b/src/evaluator/types/mod.rs
@@ -332,16 +332,22 @@ pub(crate) fn read_pattern_match(
             read_search(buffer, offset, pattern_bytes, *range)
         }
         // Flagged `string` rules go through the pattern-bearing-type
-        // contract (GOTCHAS S2.4): on hit return `Some(Value::String(
+        // contract (GOTCHAS S2.4): on hit return `Some(Value::Bytes(
         // matched_bytes))`, on miss return `None`. The engine dispatcher
         // (`evaluate_pattern_rule`) translates Some/None into Equal/NotEqual
         // and rejects other operators on the rule.
+        //
+        // The value variant is `Value::Bytes` (not `Value::String`) because
+        // libmagic semantics are byte-exact -- `from_utf8_lossy` would
+        // silently replace invalid UTF-8 with U+FFFD and break `%s`
+        // substitution. The cross-type String/Bytes equality policy in
+        // GOTCHAS S2.3 keeps downstream comparisons consistent.
         //
         // Pattern can be `Value::String` (the common case) or `Value::Bytes`
         // (parser-emitted for backslash-escape literals like `\177ELF`).
         // The trim flag (`/T`) is honored here at evaluation time so the AST
         // construction stays unchanged.
-        TypeKind::String { flags, .. } if !flags.is_empty() => {
+        TypeKind::String { max_length, flags } if !flags.is_empty() => {
             let pattern_bytes: &[u8] = match pattern {
                 Some(Value::String(s)) => s.as_bytes(),
                 Some(Value::Bytes(b)) => b.as_slice(),
@@ -370,17 +376,24 @@ pub(crate) fn read_pattern_match(
                 );
                 return Ok(None);
             }
-            match string::compare_string_with_flags(trimmed, buffer, offset, *flags) {
+            // `max_length: Some(n)` caps the scan window to `n` bytes from
+            // `offset`, matching the unflagged path's behavior. Without
+            // this, flagged matches can read past the configured window
+            // (e.g., `/w` chewing through whitespace beyond `n`). When the
+            // window is shorter than the pattern, the comparison naturally
+            // produces no match via `compare_string_with_flags`'s EOF
+            // handling -- no special case needed.
+            let scan_buffer: &[u8] = if let Some(n) = max_length {
+                let end = offset.saturating_add(*n).min(buffer.len());
+                buffer.get(..end).unwrap_or(buffer)
+            } else {
+                buffer
+            };
+            match string::compare_string_with_flags(trimmed, scan_buffer, offset, *flags) {
                 Some(consumed) => {
-                    let matched = buffer
+                    let matched = scan_buffer
                         .get(offset..offset.saturating_add(consumed))
                         .unwrap_or(&[]);
-                    // libmagic byte-exact semantics: return the matched bytes
-                    // verbatim. `from_utf8_lossy` would silently replace
-                    // non-UTF-8 sequences with U+FFFD and produce a different
-                    // byte sequence than the file actually contains, breaking
-                    // `%s` substitution and the cross-type `String`/`Bytes`
-                    // equality policy (GOTCHAS S2.3) for downstream consumers.
                     Ok(Some(Value::Bytes(matched.to_vec())))
                 }
                 None => Ok(None),
@@ -403,9 +416,22 @@ pub(crate) fn read_pattern_match(
 /// when `/w` or `/W` let the file have additional whitespace. Re-running
 /// the comparison here recovers the consumed-bytes count without storing
 /// it on the match value, matching the regex/search precedent.
+///
+/// **NUL-terminator inclusion**: when the byte immediately after the
+/// matched region is `0x00`, the consumed count includes that NUL so
+/// relative-offset children land *after* the terminator. This mirrors
+/// the unflagged-string path in `bytes_consumed_with_pattern` and is the
+/// behavior `relative_after_string_parent_includes_nul_terminator` pins
+/// for the byte-exact path.
+///
+/// **`max_length` cap**: when `max_length: Some(n)` is set, the scan is
+/// bounded to `n` bytes from `offset`, matching the unflagged path. The
+/// NUL-terminator inclusion is also clamped to this window so we cannot
+/// advance past the configured boundary.
 fn flagged_string_bytes_consumed(
     buffer: &[u8],
     offset: usize,
+    max_length: Option<usize>,
     flags: crate::parser::ast::StringFlags,
     pattern: Option<&Value>,
 ) -> usize {
@@ -437,7 +463,27 @@ fn flagged_string_bytes_consumed(
     } else {
         pattern_bytes
     };
-    string::compare_string_with_flags(effective, buffer, offset, flags).unwrap_or(0)
+    let scan_buffer: &[u8] = if let Some(n) = max_length {
+        let end = offset.saturating_add(n).min(buffer.len());
+        buffer.get(..end).unwrap_or(buffer)
+    } else {
+        buffer
+    };
+    let consumed =
+        string::compare_string_with_flags(effective, scan_buffer, offset, flags).unwrap_or(0);
+    if consumed == 0 {
+        return 0;
+    }
+    // Mirror the unflagged path: peek the byte immediately after the
+    // matched region. If it is NUL, include it in the anchor advance so
+    // relative-offset children resolve past the terminator. Bounded by
+    // the same scan window, so a `max_length`-clamped match cannot
+    // accidentally cross the cap.
+    let after = offset.saturating_add(consumed);
+    match scan_buffer.get(after) {
+        Some(&0) => consumed.saturating_add(1),
+        _ => consumed,
+    }
 }
 
 /// Trim leading and trailing ASCII whitespace from a byte slice.
@@ -595,7 +641,7 @@ pub(crate) fn bytes_consumed_with_pattern(
     match type_kind {
         TypeKind::String { max_length, flags } => {
             if !flags.is_empty() {
-                return flagged_string_bytes_consumed(buffer, offset, *flags, pattern);
+                return flagged_string_bytes_consumed(buffer, offset, *max_length, *flags, pattern);
             }
             // For the (`max_length: None`, string literal pattern)
             // combination we now compare exactly `pattern.len()` bytes

--- a/tests/relative_offset_evaluation.rs
+++ b/tests/relative_offset_evaluation.rs
@@ -219,6 +219,83 @@ fn relative_after_string_parent_includes_nul_terminator() {
     assert_eq!(matches[1].offset, 3);
 }
 
+/// Same shape as `relative_after_string_parent_includes_nul_terminator`,
+/// but the parent rule has a non-default `StringFlags` (`/c`). The
+/// flagged-string anchor-advance path must include the trailing NUL the
+/// same way as the byte-exact path does, otherwise relative-offset
+/// children land on the NUL byte instead of the byte after it.
+/// Pinned by Copilot PR #288 review (thread PRRT_kwDOP5Naes6E-VOX).
+#[test]
+fn relative_after_flagged_string_parent_includes_nul_terminator() {
+    let buffer = b"MZ\x00\x42rest";
+    let parent = MagicRule {
+        offset: OffsetSpec::Absolute(0),
+        typ: TypeKind::String {
+            max_length: None,
+            flags: StringFlags::default().with_ignore_lowercase(true),
+        },
+        op: Operator::Equal,
+        // Lowercase pattern: /c folds the file byte to lower, so "mz"
+        // matches "MZ" in the buffer. Same flagged dispatch path.
+        value: Value::String("mz".to_string()),
+        message: "mz-flagged".to_string(),
+        children: vec![child_rule(
+            OffsetSpec::Relative(0),
+            TypeKind::Byte { signed: false },
+            Value::Uint(0x42),
+            "byte-after-mz-flagged",
+        )],
+        level: 0,
+        strength_modifier: None,
+        value_transform: None,
+    };
+    let mut ctx = EvaluationContext::new(cfg());
+    let matches = evaluate_rules(&[parent], buffer, &mut ctx).unwrap();
+    assert_eq!(
+        matches.len(),
+        2,
+        "flagged-string parent + relative child should both match (NUL consumed)"
+    );
+    assert_eq!(
+        matches[1].offset, 3,
+        "child must land on byte AFTER the NUL terminator, not on it"
+    );
+}
+
+/// Flagged-string `max_length: Some(n)` must cap the scan window.
+/// Without the cap, `/w` could chew through whitespace beyond `n`
+/// bytes. Pinned by Copilot PR #288 review (thread
+/// PRRT_kwDOP5Naes6E-VOe).
+#[test]
+fn flagged_string_respects_max_length_cap() {
+    // Pattern "a b" with /w (whitespace-optional) against a buffer with
+    // long whitespace runs. Without max_length, /w would consume all
+    // the whitespace up through 'b'. With max_length: Some(2), the
+    // scan window is 2 bytes ("a " or just "ab"), which doesn't
+    // contain a 'b' to complete the match.
+    let buffer = b"a              b!";
+    let rule = MagicRule {
+        offset: OffsetSpec::Absolute(0),
+        typ: TypeKind::String {
+            max_length: Some(2),
+            flags: StringFlags::default().with_compact_optional_whitespace(true),
+        },
+        op: Operator::Equal,
+        value: Value::String("a b".to_string()),
+        message: "should-not-match".to_string(),
+        children: vec![],
+        level: 0,
+        strength_modifier: None,
+        value_transform: None,
+    };
+    let mut ctx = EvaluationContext::new(cfg());
+    let matches = evaluate_rules(&[rule], buffer, &mut ctx).unwrap();
+    assert!(
+        matches.is_empty(),
+        "max_length: Some(2) must cap the scan window before /w can reach 'b'"
+    );
+}
+
 #[test]
 fn relative_after_pstring_parent_consumes_prefix_and_payload() {
     // pstring(/B) at offset 0 with prefix 0x05, payload "Hello" (6 bytes

--- a/tests/string_flags_integration.rs
+++ b/tests/string_flags_integration.rs
@@ -131,7 +131,7 @@ fn string_b_matches_ftcomp_at_offset_24() {
 // ---------- /T: trim leading/trailing whitespace from pattern ----------
 
 #[test]
-fn string_t_trims_pattern_whitespace() {
+fn string_capital_t_trims_pattern_whitespace() {
     // Pattern has leading and trailing spaces; trim should match against
     // a buffer that contains only the inner content. This proves the
     // trim happened at evaluation time before the comparison.
@@ -239,12 +239,12 @@ fn parse_text_magic_string_b_flag_is_rejected() {
 /// `string/T "   "` would silently match every file if we let the empty
 /// post-trim pattern through to `compare_string_with_flags` (which
 /// returns `Some(0)` for an empty pattern -- the same hazard documented
-/// in GOTCHAS S2.5 for regex). The fix in `read_pattern_match` rejects
-/// the empty-after-trim case explicitly with `TypeReadError::UnsupportedType`,
-/// which the engine surfaces via `evaluate_rules` as no match (rather
-/// than a panic or universal-match).
+/// in GOTCHAS S2.5 for regex). The fix in `read_pattern_match` logs a
+/// `warn!` and returns `Ok(None)` (no match) so the malformed rule
+/// surfaces in logs without aborting evaluation of subsequent rules in
+/// the file.
 #[test]
-fn string_t_with_all_whitespace_pattern_does_not_match_everything() {
+fn string_capital_t_with_all_whitespace_pattern_does_not_match_everything() {
     let r = rule(
         0,
         "   ", // pattern is pure whitespace; trim produces empty
@@ -267,7 +267,7 @@ fn string_t_with_all_whitespace_pattern_does_not_match_everything() {
 /// match) should work: trim narrows the pattern to its non-whitespace
 /// core, then `/f` checks the byte after the matched core.
 #[test]
-fn string_t_combined_with_f_enforces_boundary_on_trimmed_core() {
+fn string_capital_t_combined_with_f_enforces_boundary_on_trimmed_core() {
     // Pattern " int " trims to "int"; /f then requires the byte after
     // "int" to be EOF or non-word.
     let r = rule(


### PR DESCRIPTION
## Summary

Follow-up to PR #288 (string-type flag semantics, issue #234) addressing the still-actionable review threads that landed after the merge. The threads were posted by `copilot-pull-request-reviewer` and `CodeRabbit`; this PR processes the substantive ones (real bugs, stale docs, missing tests) and defers a refactor-class suggestion to its own follow-up.

## Real bugs

- **`flagged_string_bytes_consumed` missed the trailing NUL terminator** that the byte-exact path includes. Relative-offset children after a flagged-string match landed on the NUL byte instead of the byte after it. Mirrors the unflagged-path `bytes_consumed_with_pattern` behavior now. Pinned by a new test, `relative_after_flagged_string_parent_includes_nul_terminator`.

- **Flagged `read_pattern_match` ignored `max_length`** on `TypeKind::String`. A `/w` rule could read past the configured window. Both `read_pattern_match` and `flagged_string_bytes_consumed` now clamp the scan buffer to `offset..offset+n` when `max_length: Some(n)`. Pinned by `flagged_string_respects_max_length_cap`.

## Stale comments and docs

- Strength penalty comments and helper docs said the penalty extended to "whitespace AND full-word flags" but `/f` is not penalized (it tightens the match; should not). Rewrote both call-site and helper rustdoc to spell out the penalized vs non-penalized lists.
- `read_pattern_match` doc said hit returns `Value::String(matched_bytes)`; implementation returns `Value::Bytes(...)` (changed in the original review-fix commit but the doc didn't follow). Fixed.
- Empty-after-trim test comment said `UnsupportedType` but code returns `Ok(None)`. Fixed.
- `docs/src/ast-structures.md` listed `is_empty(&self)` but `StringFlags: Copy` and the signature is `is_empty(self)`. Fixed.
- `docs/MAGIC_FORMAT.md` implied `pstring max_length` is part of the magic-file syntax. Grammar only accepts `/B/H/h/L/l/J`; `max_length` is reserved for programmatic construction. Doc clarified.
- `docs/src/magic-format.md` said "as of PR #234" but #234 is the issue, the actual PR is #288. Fixed.

## Test improvements

- Renamed `string_t_*` test names to `string_capital_t_*` to remove visual ambiguity with `/t`.
- Added the two regression tests cited above.
- Added `string_flag_specificity_penalty_per_flag_table` — a table-driven unit test pinning the canonical penalized/non-penalized flag list per the CodeRabbit ask.

## Deferred

- **Splitting the flagged-string engine tests into a submodule** (CodeRabbit `PRRT_kwDOP5Naes6E-aov`). The engine `tests/mod.rs` is ~2900 lines but the bloat predates PR #288; splitting is its own refactor PR.

## Threads (PR #288)

This PR addresses these threads on the original PR:

| Thread | Status |
|---|---|
| `PRRT_kwDOP5Naes6E-VNc` (AGENTS.md:234) | Already fixed pre-merge; reply + resolve on the original PR |
| `PRRT_kwDOP5Naes6E-VNq` (ast.rs:833) | Already fixed pre-merge |
| `PRRT_kwDOP5Naes6E-VNz` (string.rs:158) | Already fixed pre-merge |
| `PRRT_kwDOP5Naes6E-VOP` (types/mod.rs:388) | Already fixed pre-merge |
| `PRRT_kwDOP5Naes6E-VOD` (test name `/t` vs `/T`) | Fixed here |
| `PRRT_kwDOP5Naes6E-VOX` (NUL-terminator) | Fixed here |
| `PRRT_kwDOP5Naes6E-VOe` (`max_length` cap) | Fixed here |
| `PRRT_kwDOP5Naes6E-oXw` (test comment stale) | Fixed here |
| `PRRT_kwDOP5Naes6E-oYG` (`Value::Bytes` doc) | Fixed here |
| `PRRT_kwDOP5Naes6E-oYX` / `-oYf` / `-qsU` (strength `/f` comment) | Fixed here |
| `PRRT_kwDOP5Naes6E-oYp` (`is_empty` signature) | Fixed here |
| `PRRT_kwDOP5Naes6E-oYw` (pstring `max_length` claim) | Fixed here |
| `PRRT_kwDOP5Naes6E-oY8` (PR #234 vs #288) | Fixed here |
| `PRRT_kwDOP5Naes6E-qsX` (penalty test) | Fixed here |
| `PRRT_kwDOP5Naes6E-aov` (engine tests split) | Deferred |

## Test plan

- [x] `cargo test --all-targets` — 1173 lib tests + 194 doc tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New regression tests pass: `relative_after_flagged_string_parent_includes_nul_terminator`, `flagged_string_respects_max_length_cap`, `string_flag_specificity_penalty_per_flag_table`
