### PR TITLE
docs(magic-format): fix invalid search/T example

### DIFF
--- a/docs/src/magic-format.md
+++ b/docs/src/magic-format.md
@@ -369,7 +369,7 @@ Examples:
 0       search/2652/b  (This\ file\ must\ be\ converted\ with\ BinHex  BinHex binary text
 ```
 
-**Note on `/T` empty patterns:** `search/256/T "   "` (or any `search/N/T` with a whitespace-only pattern) trims to an empty pattern. The evaluator treats this as no-match (with a `warn!` log) rather than letting it silently match every offset. Fix the rule. Note that the `/N` range is mandatory — bare `search/T` is a parse error before evaluation ever sees the trim.
+**Note on `/T` empty patterns:** the `/N` range is mandatory, so the example must carry a window like `/256`. A rule such as `search/256/T "   "` (or any `search/N/T` with a whitespace-only pattern) trims to an empty pattern, and the evaluator treats that as no-match (with a `warn!` log) rather than letting it silently match every offset. Fix the rule. Bare `search/T` does not reach the evaluator at all -- it is a parse error before the trim ever runs.
 
 ## Operators
 

--- a/docs/src/magic-format.md
+++ b/docs/src/magic-format.md
@@ -335,17 +335,17 @@ Search flags are specified as `/flags` after the range in search types: `search/
 
 Search flags share most semantics with string flags. Eight flags (`/c`, `/C`, `/w`, `/W`, `/T`, `/f`, `/t`, `/b`) carry the same comparison-altering or metadata-hint meanings as their string-type counterparts. The ninth flag, `/s`, is search-specific: it controls where the previous-match anchor lands for relative-offset children.
 
-| Flag | Description                                                                                                     |
-| ---- | --------------------------------------------------------------------------------------------------------------- |
+| Flag | Description                                                                                                   |
+| ---- | ------------------------------------------------------------------------------------------------------------- |
 | `/s` | Start anchor: sets the previous-match anchor to match-START instead of match-END for relative-offset children |
-| `/c` | Case-insensitive (lowercase): pattern lowercase letters match both cases in buffer                             |
-| `/C` | Case-insensitive (uppercase): pattern uppercase letters match both cases in buffer                             |
-| `/w` | Optional whitespace: pattern whitespace matches zero-or-more buffer whitespace                                 |
-| `/W` | Compact whitespace: pattern whitespace requires ≥1 buffer whitespace                                           |
-| `/T` | Trim whitespace: leading/trailing whitespace in pattern is ignored                                             |
-| `/f` | Full word: post-match word boundary check (same semantics as string type)                                      |
-| `/t` | Text test hint: MIME output hint (parsed, no comparison effect)                                                |
-| `/b` | Binary test hint: MIME output hint (parsed, no comparison effect)                                              |
+| `/c` | Case-insensitive (lowercase): pattern lowercase letters match both cases in buffer                            |
+| `/C` | Case-insensitive (uppercase): pattern uppercase letters match both cases in buffer                            |
+| `/w` | Optional whitespace: pattern whitespace matches zero-or-more buffer whitespace                                |
+| `/W` | Compact whitespace: pattern whitespace requires ≥1 buffer whitespace                                          |
+| `/T` | Trim whitespace: leading/trailing whitespace in pattern is ignored                                            |
+| `/f` | Full word: post-match word boundary check (same semantics as string type)                                     |
+| `/t` | Text test hint: MIME output hint (parsed, no comparison effect)                                               |
+| `/b` | Binary test hint: MIME output hint (parsed, no comparison effect)                                             |
 
 **Performance note:** Flags `/c`, `/C`, `/w`, `/W`, `/T`, `/f` force byte-by-byte comparison, while `/s`, `/t`, `/b` preserve the fast SIMD-accelerated search path (via `memchr::memmem::find`).
 
@@ -369,7 +369,7 @@ Examples:
 0       search/2652/b  (This\ file\ must\ be\ converted\ with\ BinHex  BinHex binary text
 ```
 
-**Note on `/T` empty patterns:** `search/T "   "` trims to an empty pattern. The evaluator treats this as no-match (with a `warn!` log) rather than letting it silently match every offset. Fix the rule.
+**Note on `/T` empty patterns:** `search/256/T "   "` (or any `search/N/T` with a whitespace-only pattern) trims to an empty pattern. The evaluator treats this as no-match (with a `warn!` log) rather than letting it silently match every offset. Fix the rule. Note that the `/N` range is mandatory — bare `search/T` is a parse error before evaluation ever sees the trim.
 
 ## Operators
 


### PR DESCRIPTION
## Summary

- Replace the unparseable `search/T "   "` example in the `/T` empty-pattern note with `search/256/T "   "`.
- Add an explicit note that the `/N` range is mandatory so the parse-error path is documented alongside the evaluator no-match path.

The original example couldn't actually exercise the trim-to-empty behavior it was illustrating: `parse_search_suffix` requires a `NonZeroUsize` range, so bare `search/T` is rejected at parse time (covered by `test_parse_search_suffix_empty_rejected` in `src/parser/grammar/type_suffix.rs`). Readers copying the broken form would see a parse error, not the warn-and-no-match behavior described.

Incidental: mdformat trimmed trailing whitespace in the adjacent `Search Flags` table during pre-commit; that's unrelated to the substantive change but unavoidable on this hook chain.

## Test plan

- [x] `grep` confirms the broken `search/T "   "` form is gone from `docs/src/magic-format.md` and the corrected `search/256/T "   "` is present.
- [ ] CI doc build (if wired) renders the section without warnings.
- [ ] Visual spot-check of the rendered note in the book preview.