### PR TITLE
fix: resolve daily audit and cargo-dist plan CI failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -120,7 +120,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -151,7 +151,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
@@ -185,7 +185,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -254,7 +254,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -319,7 +319,7 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: true
           repository: "EvilBit-Labs/homebrew-tap"
@@ -366,7 +366,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1054,7 +1054,7 @@ mod tests {
         // Verify all matches have proper rule paths
         for match_result in &result.matches {
             assert!(!match_result.rule_path.is_empty());
-            assert!(match_result.rule_path[0] == "elf");
+            assert_eq!(match_result.rule_path[0], "elf");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two independent causes of the daily red CI on `main`:

1. **`audit` job** — `cargo update -p anyhow -p crossbeam-epoch`:
   - anyhow 1.0.102 -> 1.0.103 (RUSTSEC-2026-0190, unsoundness in `Error::downcast_mut`)
   - crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204, invalid pointer deref in `fmt::Display`)

   Closes #352, closes #361.

2. **`plan` job (Security workflow)** — regenerated `.github/workflows/release.yml` via `dist generate` (cargo-dist 0.31.0). Dependabot #337 had bumped `actions/checkout` to v7.0.0 inside the generated file, which dist's drift check rejects (it pins v6.0.2).

Also includes a one-line pre-existing test fix (`assert!` -> `assert_eq!`) flagged by the new `manual_assert_eq` lint in clippy 1.97, keeping the zero-warnings policy intact on newer toolchains.

Supersedes #343 (generated before #337 landed, so its regeneration no longer matches main).

## Test plan

- [x] `cargo audit` clean (exit 0, no advisories)
- [x] `cargo deny check` — advisories/bans/licenses/sources all ok
- [x] `cargo clippy --all-targets -- -D warnings` clean on rust 1.97
- [x] `cargo nextest run` — 1482 passed, 6 skipped
- [x] `cargo fmt --check` clean
- [ ] CI green on this PR (audit + plan jobs should now pass)

## Notes

Prevention follow-up worth considering: dependabot will re-bump `checkout` in `release.yml` on its next cycle; either ignore `actions/checkout` for the github-actions ecosystem or regenerate with a dist version that pins v7.